### PR TITLE
Explicitly specify used winapi features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,12 @@ errno = "0.2"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["profileapi", "sysinfoapi"] }
+winapi = { version = "0.3", features = [
+    "profileapi",
+    "sysinfoapi",
+    "errhandlingapi",
+    "processthreadsapi",
+] }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Fixes #3

This is necessary to compile howlong with resolver="2".
resolver="2" uses more selective feature unification mechanism
(see https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2).

howlong relies on 'errhandlingapi' and 'processthreadsapi' features of
the winapi crate. It probably worked by accident with resolver="1",
maybe because some dev dependency or something was indirectly using
winapi with these features. I don't feel like investigating
the specifics.